### PR TITLE
Wording consistency with other Nextcloud apps

### DIFF
--- a/src/vue/Components/Navigation/AppNavigation.vue
+++ b/src/vue/Components/Navigation/AppNavigation.vue
@@ -31,7 +31,7 @@
         </template>
 
         <nc-app-navigation-settings slot="footer" :title="t('More')">
-            <app-navigation-item :name="t('Settings')" :to="{ name: 'Settings'}">
+            <app-navigation-item :name="t('Passwords settings')" :to="{ name: 'Settings'}">
                 <cog-icon :size=20 slot="icon" />
             </app-navigation-item>
             <app-navigation-item :name="t('Backup and Restore')" :to="{ name: 'Backup'}">


### PR DESCRIPTION
Signed-off-by: Jérôme Herbinet <33763786+Jerome-Herbinet@users.noreply.github.com>

Wording consistency with other Nextcloud apps because in other Nextcloud apps, the settings button's wording is : 

"{name of the app} settings"